### PR TITLE
fix: Add redis db number to url

### DIFF
--- a/src/redis.ts
+++ b/src/redis.ts
@@ -4,16 +4,19 @@
  */
 
 import Config, { ConfigProvider } from '@kapeta/sdk-config';
-import {createClient, RedisClientType, RedisClientOptions} from 'redis';
-
+import { createClient, RedisClientType, RedisClientOptions } from 'redis';
 
 const RESOURCE_TYPE = 'kapeta/resource-type-redis';
 const PORT_TYPE = 'redis';
 
 export type RedisClient = RedisClientType;
-export type RedisOptions = Omit<RedisClientOptions, 'url'|'username'|'password'|'socket'>
+export type RedisOptions = Omit<RedisClientOptions, 'url' | 'username' | 'password' | 'socket'>;
 
-export const createRedisClient = async (config: ConfigProvider, resourceName: string, options?:RedisOptions):Promise<RedisClient> => {
+export const createRedisClient = async (
+    config: ConfigProvider,
+    resourceName: string,
+    options?: RedisOptions
+): Promise<RedisClient> => {
     const redisInfo = await config.getResourceInfo(RESOURCE_TYPE, PORT_TYPE, resourceName);
     if (!redisInfo) {
         throw new Error(`Resource ${resourceName} not found`);
@@ -31,13 +34,17 @@ export const createRedisClient = async (config: ConfigProvider, resourceName: st
         url += '@';
     }
 
-    const redisHostname = `${redisInfo.host}:${redisInfo.port}`;
+    let redisHostname = `${redisInfo.host}:${redisInfo.port}`;
+
+    if (redisInfo.options?.database) {
+        redisHostname += `/${redisInfo.options.database}`;
+    }
 
     url += `${redisHostname}`;
 
     console.log(`Connecting to Redis: ${redisHostname}`);
 
-    const client:RedisClient = createClient({ ...options, ...redisOptions, url }) as RedisClient;
+    const client: RedisClient = createClient({ ...options, ...redisOptions, url }) as RedisClient;
 
     try {
         await client.connect();
@@ -53,26 +60,25 @@ export const createRedisClient = async (config: ConfigProvider, resourceName: st
 
 export class RedisDB {
     private readonly resourceName: string;
-    private _client: RedisClient|undefined;
-    private options:RedisOptions
+    private _client: RedisClient | undefined;
+    private options: RedisOptions;
 
-    constructor(resourceName:string, options?:RedisOptions) {
+    constructor(resourceName: string, options?: RedisOptions) {
         this.resourceName = resourceName;
         this.options = options ?? {};
-        Config.onReady(async (provider:ConfigProvider) => {
+        Config.onReady(async (provider: ConfigProvider) => {
             await this.init(provider);
-        })
+        });
     }
 
-    private async init(provider:ConfigProvider) {
+    private async init(provider: ConfigProvider) {
         this._client = await createRedisClient(provider, this.resourceName, this.options);
     }
 
-    public client():RedisClient {
+    public client(): RedisClient {
         if (!this._client) {
             throw new Error('RedisDB not ready');
         }
         return this._client;
     }
-
 }


### PR DESCRIPTION
It looks like the database number [has to be in the pathname](https://github.com/redis/node-redis/blob/5a96058c2f77c1278a0438ca5923f0772cf74790/packages/client/lib/client/index.ts#L187-L194) even though there is an option to pass it in as `options`. 

This PR keeps the database number in the options object and adds it to the URL as well.
